### PR TITLE
Fix option mismatch (repo-url vs repo-uri)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ runs:
       run: |
         unset LD_PRELOAD
         unset PYTHONSTARTUP
-        python3 "${{ github.action_path }}/dart_analyzer_sarif.py" "${{ inputs.input }}" "${{ inputs.output }}" "${{ inputs.sourceroot }}" --repo-url "${{ github.server_url }}/${{ github.repository }}" --branch "${{ github.ref }}" --revision-id "${{ github.sha }}"
+        python3 "${{ github.action_path }}/dart_analyzer_sarif.py" "${{ inputs.input }}" "${{ inputs.output }}" "${{ inputs.sourceroot }}" --repo-uri "${{ github.server_url }}/${{ github.repository }}" --branch "${{ github.ref }}" --revision-id "${{ github.sha }}"
       shell: bash


### PR DESCRIPTION
Hi 👋 . This PR intends to fix the option-name mismatch between `action.yml` and `dart_analyzer_sarif.py`.

**Background**

- When I tried to apply the `advanced-security/dart-analyzer-sarif@main`, the following error was displayed.

```Run advanced-security/dart-analyzer-sarif@main
Run unset LD_PRELOAD
usage: dart_analyzer_sarif.py [-h] [--repo-uri REPO_URI]
                              [--revision-id REVISION_ID] [--branch BRANCH]
                              [--debug]
                              input_file output_file source_root
dart_analyzer_sarif.py: error: unrecognized arguments: --repo-url https://github.com/xxx/yyy
Error: Process completed with exit code 2.
```